### PR TITLE
[ISSUE 25]Describe table command should show metadata associated with the astro table

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLContext.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLContext.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.OverrideCatalog
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.execution.{EnsureRequirements, SparkPlan}
-import org.apache.spark.sql.hbase.execution.{AddCoprocessor, HBaseStrategies}
+import org.apache.spark.sql.hbase.execution.{AddCoprocessor, HBaseCommandStrategy, HBaseStrategies}
 
 class HBaseSQLContext(sc: SparkContext) extends SQLContext(sc) {
   self =>
@@ -40,7 +40,10 @@ class HBaseSQLContext(sc: SparkContext) extends SQLContext(sc) {
   override protected[sql] lazy val catalog: HBaseCatalog =
     new HBaseCatalog(this, sc.hadoopConfiguration) with OverrideCatalog
 
-  experimental.extraStrategies = Seq((new SparkPlanner with HBaseStrategies).HBaseDataSource)
+  experimental.extraStrategies =
+    Seq((
+    new SparkPlanner with HBaseStrategies).HBaseDataSource,
+    HBaseCommandStrategy(self))
 
   @transient
   override protected[sql] val prepareForExecution = new RuleExecutor[SparkPlan] {

--- a/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLParser.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLParser.scala
@@ -62,7 +62,7 @@ class HBaseSQLParser extends SqlParser {
   override protected lazy val start: Parser[LogicalPlan] =
     start1 | insert | cte |
       create | drop | alterDrop | alterAdd |
-      insertValues | load | show | describe
+      insertValues | load | show //| describe
 
   protected lazy val insertValues: Parser[LogicalPlan] =
     INSERT ~> INTO ~> TABLE ~> ident ~ (VALUES ~> "(" ~> values <~ ")") ^^ {
@@ -226,10 +226,10 @@ class HBaseSQLParser extends SqlParser {
   protected lazy val show: Parser[LogicalPlan] =
     SHOW ~> TABLES <~ opt(";") ^^^ ShowTablesCommand
 
-  protected lazy val describe: Parser[LogicalPlan] =
-    (DESCRIBE ~> ident) ^^ {
-      case tableName => DescribeTableCommand(tableName)
-    }
+//  protected lazy val describe: Parser[LogicalPlan] =
+//    (DESCRIBE ~> ident) ^^ {
+//      case tableName => DescribeTableCommand(tableName)
+//    }
 
   override protected lazy val primitiveType: Parser[DataType] =
     "(?i)string".r ^^^ StringType |


### PR DESCRIPTION
describe table command is not working as per design. It should show metadata associated with the astro table, but currently it is delegated to sparksql's describe command, which is not correct behavior.
Now it is overriding DescribeCommand in Astro to execute it in Astro.