### PR TITLE
support composited rowkey when read pre-load hbase data

### DIFF
--- a/src/main/java/org/apache/spark/sql/hbase/CheckDirProtos.java
+++ b/src/main/java/org/apache/spark/sql/hbase/CheckDirProtos.java
@@ -4,1072 +4,1139 @@
 package org.apache.spark.sql.hbase;
 
 public final class CheckDirProtos {
-  private CheckDirProtos() {}
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
-  }
-  public interface CheckRequestOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-  }
-  /**
-   * Protobuf type {@code CheckRequest}
-   */
-  public static final class CheckRequest extends
-      com.google.protobuf.GeneratedMessage
-      implements CheckRequestOrBuilder {
-    // Use CheckRequest.newBuilder() to construct.
-    private CheckRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
-    }
-    private CheckRequest(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+    private static com.google.protobuf.Descriptors.Descriptor
+            internal_static_CheckRequest_descriptor;
+    private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internal_static_CheckRequest_fieldAccessorTable;
+    private static com.google.protobuf.Descriptors.Descriptor
+            internal_static_CheckResponse_descriptor;
+    private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internal_static_CheckResponse_fieldAccessorTable;
+    private static com.google.protobuf.Descriptors.FileDescriptor
+            descriptor;
 
-    private static final CheckRequest defaultInstance;
-    public static CheckRequest getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public CheckRequest getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private CheckRequest(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_descriptor;
+    static {
+        java.lang.String[] descriptorData = {
+                "\n\025CheckDirService.proto\"\016\n\014CheckRequest\"" +
+                        "#\n\rCheckResponse\022\022\n\naccessible\030\001 \002(\0102B\n\017" +
+                        "CheckDirService\022/\n\016getCheckResult\022\r.Chec" +
+                        "kRequest\032\016.CheckResponseB4\n\032org.apache.s" +
+                        "park.sql.hbaseB\016CheckDirProtosH\001\210\001\001\240\001\001"
+        };
+        com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
+                new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
+                    public com.google.protobuf.ExtensionRegistry assignDescriptors(
+                            com.google.protobuf.Descriptors.FileDescriptor root) {
+                        descriptor = root;
+                        internal_static_CheckRequest_descriptor =
+                                getDescriptor().getMessageTypes().get(0);
+                        internal_static_CheckRequest_fieldAccessorTable = new
+                                com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+                                internal_static_CheckRequest_descriptor,
+                                new java.lang.String[]{});
+                        internal_static_CheckResponse_descriptor =
+                                getDescriptor().getMessageTypes().get(1);
+                        internal_static_CheckResponse_fieldAccessorTable = new
+                                com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+                                internal_static_CheckResponse_descriptor,
+                                new java.lang.String[]{"Accessible",});
+                        return null;
+                    }
+                };
+        com.google.protobuf.Descriptors.FileDescriptor
+                .internalBuildGeneratedFileFrom(descriptorData,
+                        new com.google.protobuf.Descriptors.FileDescriptor[]{
+                        }, assigner);
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.class, org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.Builder.class);
+    private CheckDirProtos() {
     }
 
-    public static com.google.protobuf.Parser<CheckRequest> PARSER =
-        new com.google.protobuf.AbstractParser<CheckRequest>() {
-      public CheckRequest parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CheckRequest(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<CheckRequest> getParserForType() {
-      return PARSER;
+    public static void registerAllExtensions(
+            com.google.protobuf.ExtensionRegistry registry) {
     }
 
-    private void initFields() {
+    public static com.google.protobuf.Descriptors.FileDescriptor
+    getDescriptor() {
+        return descriptor;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-
-      memoizedIsInitialized = 1;
-      return true;
+    public interface CheckRequestOrBuilder
+            extends com.google.protobuf.MessageOrBuilder {
     }
+    public interface CheckResponseOrBuilder
+            extends com.google.protobuf.MessageOrBuilder {
 
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      getSerializedSize();
-      getUnknownFields().writeTo(output);
-    }
+        // required bool accessible = 1;
 
-    private int memoizedSerializedSize = -1;
-    public int getSerializedSize() {
-      int size = memoizedSerializedSize;
-      if (size != -1) return size;
+        /**
+         * <code>required bool accessible = 1;</code>
+         */
+        boolean hasAccessible();
 
-      size = 0;
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
-      return size;
+        /**
+         * <code>required bool accessible = 1;</code>
+         */
+        boolean getAccessible();
     }
 
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
-    }
-
-    @java.lang.Override
-    public boolean equals(final java.lang.Object obj) {
-      if (obj == this) {
-       return true;
-      }
-      if (!(obj instanceof org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest)) {
-        return super.equals(obj);
-      }
-      org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest other = (org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest) obj;
-
-      boolean result = true;
-      result = result &&
-          getUnknownFields().equals(other.getUnknownFields());
-      return result;
-    }
-
-    private int memoizedHashCode = 0;
-    @java.lang.Override
-    public int hashCode() {
-      if (memoizedHashCode != 0) {
-        return memoizedHashCode;
-      }
-      int hash = 41;
-      hash = (19 * hash) + getDescriptorForType().hashCode();
-      hash = (29 * hash) + getUnknownFields().hashCode();
-      memoizedHashCode = hash;
-      return hash;
-    }
-
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-    public Builder toBuilder() { return newBuilder(this); }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code CheckRequest}
      */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.spark.sql.hbase.CheckDirProtos.CheckRequestOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_descriptor;
-      }
+    public static final class CheckRequest extends
+            com.google.protobuf.GeneratedMessage
+            implements CheckRequestOrBuilder {
+        private static final CheckRequest defaultInstance;
+        private static final long serialVersionUID = 0L;
+        public static com.google.protobuf.Parser<CheckRequest> PARSER =
+                new com.google.protobuf.AbstractParser<CheckRequest>() {
+                    public CheckRequest parsePartialFrom(
+                            com.google.protobuf.CodedInputStream input,
+                            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                            throws com.google.protobuf.InvalidProtocolBufferException {
+                        return new CheckRequest(input, extensionRegistry);
+                    }
+                };
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.class, org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.Builder.class);
-      }
-
-      // Construct using org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        static {
+            defaultInstance = new CheckRequest(true);
+            defaultInstance.initFields();
         }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        return this;
-      }
+        private final com.google.protobuf.UnknownFieldSet unknownFields;
+        private byte memoizedIsInitialized = -1;
+        private int memoizedSerializedSize = -1;
+        private int memoizedHashCode = 0;
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_descriptor;
-      }
-
-      public org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest getDefaultInstanceForType() {
-        return org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.getDefaultInstance();
-      }
-
-      public org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest build() {
-        org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
+        // Use CheckRequest.newBuilder() to construct.
+        private CheckRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+            super(builder);
+            this.unknownFields = builder.getUnknownFields();
         }
-        return result;
-      }
 
-      public org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest buildPartial() {
-        org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest result = new org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest(this);
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest) {
-          return mergeFrom((org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
+        private CheckRequest(boolean noInit) {
+            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
         }
-      }
 
-      public Builder mergeFrom(org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest other) {
-        if (other == org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.getDefaultInstance()) return this;
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-
-      // @@protoc_insertion_point(builder_scope:CheckRequest)
-    }
-
-    static {
-      defaultInstance = new CheckRequest(true);
-      defaultInstance.initFields();
-    }
-
-    // @@protoc_insertion_point(class_scope:CheckRequest)
-  }
-
-  public interface CheckResponseOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-
-    // required bool accessible = 1;
-    /**
-     * <code>required bool accessible = 1;</code>
-     */
-    boolean hasAccessible();
-    /**
-     * <code>required bool accessible = 1;</code>
-     */
-    boolean getAccessible();
-  }
-  /**
-   * Protobuf type {@code CheckResponse}
-   */
-  public static final class CheckResponse extends
-      com.google.protobuf.GeneratedMessage
-      implements CheckResponseOrBuilder {
-    // Use CheckResponse.newBuilder() to construct.
-    private CheckResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
-    }
-    private CheckResponse(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final CheckResponse defaultInstance;
-    public static CheckResponse getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public CheckResponse getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private CheckResponse(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
+        private CheckRequest(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            initFields();
+            com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+                    com.google.protobuf.UnknownFieldSet.newBuilder();
+            try {
+                boolean done = false;
+                while (!done) {
+                    int tag = input.readTag();
+                    switch (tag) {
+                        case 0:
+                            done = true;
+                            break;
+                        default: {
+                            if (!parseUnknownField(input, unknownFields,
+                                    extensionRegistry, tag)) {
+                                done = true;
+                            }
+                            break;
+                        }
+                    }
+                }
+            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw e.setUnfinishedMessage(this);
+            } catch (java.io.IOException e) {
+                throw new com.google.protobuf.InvalidProtocolBufferException(
+                        e.getMessage()).setUnfinishedMessage(this);
+            } finally {
+                this.unknownFields = unknownFields.build();
+                makeExtensionsImmutable();
             }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              accessible_ = input.readBool();
-              break;
-            }
-          }
         }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
+
+        public static CheckRequest getDefaultInstance() {
+            return defaultInstance;
+        }
+
+        public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_descriptor;
-    }
+            return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_descriptor;
+        }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
+                com.google.protobuf.ByteString data)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
+                com.google.protobuf.ByteString data,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data, extensionRegistry);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(byte[] data)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
+                byte[] data,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data, extensionRegistry);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(java.io.InputStream input)
+                throws java.io.IOException {
+            return PARSER.parseFrom(input);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
+                java.io.InputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
+            return PARSER.parseFrom(input, extensionRegistry);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseDelimitedFrom(java.io.InputStream input)
+                throws java.io.IOException {
+            return PARSER.parseDelimitedFrom(input);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseDelimitedFrom(
+                java.io.InputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
+            return PARSER.parseDelimitedFrom(input, extensionRegistry);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
+                com.google.protobuf.CodedInputStream input)
+                throws java.io.IOException {
+            return PARSER.parseFrom(input);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parseFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
+            return PARSER.parseFrom(input, extensionRegistry);
+        }
+
+        public static Builder newBuilder() {
+            return Builder.create();
+        }
+
+        public static Builder newBuilder(org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest prototype) {
+            return newBuilder().mergeFrom(prototype);
+        }
+
+        public CheckRequest getDefaultInstanceForType() {
+            return defaultInstance;
+        }
+
+        @java.lang.Override
+        public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+            return this.unknownFields;
+        }
+
+        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.class, org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.Builder.class);
+            return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_fieldAccessorTable
+                    .ensureFieldAccessorsInitialized(
+                            org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.class, org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.Builder.class);
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Parser<CheckRequest> getParserForType() {
+            return PARSER;
+        }
+
+        private void initFields() {
+        }
+
+        public final boolean isInitialized() {
+            byte isInitialized = memoizedIsInitialized;
+            if (isInitialized != -1) return isInitialized == 1;
+
+            memoizedIsInitialized = 1;
+            return true;
+        }
+
+        public void writeTo(com.google.protobuf.CodedOutputStream output)
+                throws java.io.IOException {
+            getSerializedSize();
+            getUnknownFields().writeTo(output);
+        }
+
+        public int getSerializedSize() {
+            int size = memoizedSerializedSize;
+            if (size != -1) return size;
+
+            size = 0;
+            size += getUnknownFields().getSerializedSize();
+            memoizedSerializedSize = size;
+            return size;
+        }
+
+        @java.lang.Override
+        protected java.lang.Object writeReplace()
+                throws java.io.ObjectStreamException {
+            return super.writeReplace();
+        }
+
+        @java.lang.Override
+        public boolean equals(final java.lang.Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (!(obj instanceof org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest)) {
+                return super.equals(obj);
+            }
+            org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest other = (org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest) obj;
+
+            boolean result = true;
+            result = result &&
+                    getUnknownFields().equals(other.getUnknownFields());
+            return result;
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+            if (memoizedHashCode != 0) {
+                return memoizedHashCode;
+            }
+            int hash = 41;
+            hash = (19 * hash) + getDescriptorForType().hashCode();
+            hash = (29 * hash) + getUnknownFields().hashCode();
+            memoizedHashCode = hash;
+            return hash;
+        }
+
+        public Builder newBuilderForType() {
+            return newBuilder();
+        }
+
+        public Builder toBuilder() {
+            return newBuilder(this);
+        }
+
+        @java.lang.Override
+        protected Builder newBuilderForType(
+                com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            Builder builder = new Builder(parent);
+            return builder;
+        }
+
+        /**
+         * Protobuf type {@code CheckRequest}
+         */
+        public static final class Builder extends
+                com.google.protobuf.GeneratedMessage.Builder<Builder>
+                implements org.apache.spark.sql.hbase.CheckDirProtos.CheckRequestOrBuilder {
+            // Construct using org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.newBuilder()
+            private Builder() {
+                maybeForceBuilderInitialization();
+            }
+
+            private Builder(
+                    com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+                super(parent);
+                maybeForceBuilderInitialization();
+            }
+
+            public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+                return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_descriptor;
+            }
+
+            private static Builder create() {
+                return new Builder();
+            }
+
+            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+                return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_fieldAccessorTable
+                        .ensureFieldAccessorsInitialized(
+                                org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.class, org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.Builder.class);
+            }
+
+            private void maybeForceBuilderInitialization() {
+                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+                }
+            }
+
+            public Builder clear() {
+                super.clear();
+                return this;
+            }
+
+            public Builder clone() {
+                return create().mergeFrom(buildPartial());
+            }
+
+            public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+                return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckRequest_descriptor;
+            }
+
+            public org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest getDefaultInstanceForType() {
+                return org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.getDefaultInstance();
+            }
+
+            public org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest build() {
+                org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest result = buildPartial();
+                if (!result.isInitialized()) {
+                    throw newUninitializedMessageException(result);
+                }
+                return result;
+            }
+
+            public org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest buildPartial() {
+                org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest result = new org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest(this);
+                onBuilt();
+                return result;
+            }
+
+            public Builder mergeFrom(com.google.protobuf.Message other) {
+                if (other instanceof org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest) {
+                    return mergeFrom((org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest) other);
+                } else {
+                    super.mergeFrom(other);
+                    return this;
+                }
+            }
+
+            public Builder mergeFrom(org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest other) {
+                if (other == org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.getDefaultInstance()) return this;
+                this.mergeUnknownFields(other.getUnknownFields());
+                return this;
+            }
+
+            public final boolean isInitialized() {
+                return true;
+            }
+
+            public Builder mergeFrom(
+                    com.google.protobuf.CodedInputStream input,
+                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                    throws java.io.IOException {
+                org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest parsedMessage = null;
+                try {
+                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                    parsedMessage = (org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest) e.getUnfinishedMessage();
+                    throw e;
+                } finally {
+                    if (parsedMessage != null) {
+                        mergeFrom(parsedMessage);
+                    }
+                }
+                return this;
+            }
+
+            // @@protoc_insertion_point(builder_scope:CheckRequest)
+        }
+
+        // @@protoc_insertion_point(class_scope:CheckRequest)
     }
 
-    public static com.google.protobuf.Parser<CheckResponse> PARSER =
-        new com.google.protobuf.AbstractParser<CheckResponse>() {
-      public CheckResponse parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CheckResponse(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<CheckResponse> getParserForType() {
-      return PARSER;
-    }
-
-    private int bitField0_;
-    // required bool accessible = 1;
-    public static final int ACCESSIBLE_FIELD_NUMBER = 1;
-    private boolean accessible_;
-    /**
-     * <code>required bool accessible = 1;</code>
-     */
-    public boolean hasAccessible() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
-    }
-    /**
-     * <code>required bool accessible = 1;</code>
-     */
-    public boolean getAccessible() {
-      return accessible_;
-    }
-
-    private void initFields() {
-      accessible_ = false;
-    }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-
-      if (!hasAccessible()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBool(1, accessible_);
-      }
-      getUnknownFields().writeTo(output);
-    }
-
-    private int memoizedSerializedSize = -1;
-    public int getSerializedSize() {
-      int size = memoizedSerializedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBoolSize(1, accessible_);
-      }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
-      return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
-    }
-
-    @java.lang.Override
-    public boolean equals(final java.lang.Object obj) {
-      if (obj == this) {
-       return true;
-      }
-      if (!(obj instanceof org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse)) {
-        return super.equals(obj);
-      }
-      org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse other = (org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse) obj;
-
-      boolean result = true;
-      result = result && (hasAccessible() == other.hasAccessible());
-      if (hasAccessible()) {
-        result = result && (getAccessible()
-            == other.getAccessible());
-      }
-      result = result &&
-          getUnknownFields().equals(other.getUnknownFields());
-      return result;
-    }
-
-    private int memoizedHashCode = 0;
-    @java.lang.Override
-    public int hashCode() {
-      if (memoizedHashCode != 0) {
-        return memoizedHashCode;
-      }
-      int hash = 41;
-      hash = (19 * hash) + getDescriptorForType().hashCode();
-      if (hasAccessible()) {
-        hash = (37 * hash) + ACCESSIBLE_FIELD_NUMBER;
-        hash = (53 * hash) + hashBoolean(getAccessible());
-      }
-      hash = (29 * hash) + getUnknownFields().hashCode();
-      memoizedHashCode = hash;
-      return hash;
-    }
-
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-    public Builder toBuilder() { return newBuilder(this); }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code CheckResponse}
      */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.spark.sql.hbase.CheckDirProtos.CheckResponseOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_descriptor;
-      }
+    public static final class CheckResponse extends
+            com.google.protobuf.GeneratedMessage
+            implements CheckResponseOrBuilder {
+        // required bool accessible = 1;
+        public static final int ACCESSIBLE_FIELD_NUMBER = 1;
+        private static final CheckResponse defaultInstance;
+        private static final long serialVersionUID = 0L;
+        public static com.google.protobuf.Parser<CheckResponse> PARSER =
+                new com.google.protobuf.AbstractParser<CheckResponse>() {
+                    public CheckResponse parsePartialFrom(
+                            com.google.protobuf.CodedInputStream input,
+                            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                            throws com.google.protobuf.InvalidProtocolBufferException {
+                        return new CheckResponse(input, extensionRegistry);
+                    }
+                };
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.class, org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.Builder.class);
-      }
-
-      // Construct using org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        static {
+            defaultInstance = new CheckResponse(true);
+            defaultInstance.initFields();
         }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        accessible_ = false;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        return this;
-      }
+        private final com.google.protobuf.UnknownFieldSet unknownFields;
+        private int bitField0_;
+        private boolean accessible_;
+        private byte memoizedIsInitialized = -1;
+        private int memoizedSerializedSize = -1;
+        private int memoizedHashCode = 0;
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_descriptor;
-      }
-
-      public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse getDefaultInstanceForType() {
-        return org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance();
-      }
-
-      public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse build() {
-        org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
+        // Use CheckResponse.newBuilder() to construct.
+        private CheckResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+            super(builder);
+            this.unknownFields = builder.getUnknownFields();
         }
-        return result;
-      }
 
-      public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse buildPartial() {
-        org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse result = new org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
+        private CheckResponse(boolean noInit) {
+            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
         }
-        result.accessible_ = accessible_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse) {
-          return mergeFrom((org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
+        private CheckResponse(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            initFields();
+            int mutable_bitField0_ = 0;
+            com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+                    com.google.protobuf.UnknownFieldSet.newBuilder();
+            try {
+                boolean done = false;
+                while (!done) {
+                    int tag = input.readTag();
+                    switch (tag) {
+                        case 0:
+                            done = true;
+                            break;
+                        default: {
+                            if (!parseUnknownField(input, unknownFields,
+                                    extensionRegistry, tag)) {
+                                done = true;
+                            }
+                            break;
+                        }
+                        case 8: {
+                            bitField0_ |= 0x00000001;
+                            accessible_ = input.readBool();
+                            break;
+                        }
+                    }
+                }
+            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw e.setUnfinishedMessage(this);
+            } catch (java.io.IOException e) {
+                throw new com.google.protobuf.InvalidProtocolBufferException(
+                        e.getMessage()).setUnfinishedMessage(this);
+            } finally {
+                this.unknownFields = unknownFields.build();
+                makeExtensionsImmutable();
+            }
         }
-      }
 
-      public Builder mergeFrom(org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse other) {
-        if (other == org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance()) return this;
-        if (other.hasAccessible()) {
-          setAccessible(other.getAccessible());
+        public static CheckResponse getDefaultInstance() {
+            return defaultInstance;
         }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
 
-      public final boolean isInitialized() {
-        if (!hasAccessible()) {
-          
-          return false;
+        public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+            return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_descriptor;
         }
-        return true;
-      }
 
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
+                com.google.protobuf.ByteString data)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data);
         }
-        return this;
-      }
-      private int bitField0_;
 
-      // required bool accessible = 1;
-      private boolean accessible_ ;
-      /**
-       * <code>required bool accessible = 1;</code>
-       */
-      public boolean hasAccessible() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
-      }
-      /**
-       * <code>required bool accessible = 1;</code>
-       */
-      public boolean getAccessible() {
-        return accessible_;
-      }
-      /**
-       * <code>required bool accessible = 1;</code>
-       */
-      public Builder setAccessible(boolean value) {
-        bitField0_ |= 0x00000001;
-        accessible_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>required bool accessible = 1;</code>
-       */
-      public Builder clearAccessible() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        accessible_ = false;
-        onChanged();
-        return this;
-      }
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
+                com.google.protobuf.ByteString data,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data, extensionRegistry);
+        }
 
-      // @@protoc_insertion_point(builder_scope:CheckResponse)
-    }
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(byte[] data)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data);
+        }
 
-    static {
-      defaultInstance = new CheckResponse(true);
-      defaultInstance.initFields();
-    }
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
+                byte[] data,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data, extensionRegistry);
+        }
 
-    // @@protoc_insertion_point(class_scope:CheckResponse)
-  }
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(java.io.InputStream input)
+                throws java.io.IOException {
+            return PARSER.parseFrom(input);
+        }
 
-  /**
-   * Protobuf service {@code CheckDirService}
-   */
-  public static abstract class CheckDirService
-      implements com.google.protobuf.Service {
-    protected CheckDirService() {}
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
+                java.io.InputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
+            return PARSER.parseFrom(input, extensionRegistry);
+        }
 
-    public interface Interface {
-      /**
-       * <code>rpc getCheckResult(.CheckRequest) returns (.CheckResponse);</code>
-       */
-      public abstract void getCheckResult(
-          com.google.protobuf.RpcController controller,
-          org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request,
-          com.google.protobuf.RpcCallback<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse> done);
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseDelimitedFrom(java.io.InputStream input)
+                throws java.io.IOException {
+            return PARSER.parseDelimitedFrom(input);
+        }
 
-    }
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseDelimitedFrom(
+                java.io.InputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
+            return PARSER.parseDelimitedFrom(input, extensionRegistry);
+        }
 
-    public static com.google.protobuf.Service newReflectiveService(
-        final Interface impl) {
-      return new CheckDirService() {
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
+                com.google.protobuf.CodedInputStream input)
+                throws java.io.IOException {
+            return PARSER.parseFrom(input);
+        }
+
+        public static org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parseFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
+            return PARSER.parseFrom(input, extensionRegistry);
+        }
+
+        public static Builder newBuilder() {
+            return Builder.create();
+        }
+
+        public static Builder newBuilder(org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse prototype) {
+            return newBuilder().mergeFrom(prototype);
+        }
+
+        public CheckResponse getDefaultInstanceForType() {
+            return defaultInstance;
+        }
+
         @java.lang.Override
-        public  void getCheckResult(
-            com.google.protobuf.RpcController controller,
-            org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request,
-            com.google.protobuf.RpcCallback<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse> done) {
-          impl.getCheckResult(controller, request, done);
+        public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+            return this.unknownFields;
         }
 
-      };
-    }
+        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+            return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_fieldAccessorTable
+                    .ensureFieldAccessorsInitialized(
+                            org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.class, org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.Builder.class);
+        }
 
-    public static com.google.protobuf.BlockingService
-        newReflectiveBlockingService(final BlockingInterface impl) {
-      return new com.google.protobuf.BlockingService() {
-        public final com.google.protobuf.Descriptors.ServiceDescriptor
+        @java.lang.Override
+        public com.google.protobuf.Parser<CheckResponse> getParserForType() {
+            return PARSER;
+        }
+
+        /**
+         * <code>required bool accessible = 1;</code>
+         */
+        public boolean hasAccessible() {
+            return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+
+        /**
+         * <code>required bool accessible = 1;</code>
+         */
+        public boolean getAccessible() {
+            return accessible_;
+        }
+
+        private void initFields() {
+            accessible_ = false;
+        }
+
+        public final boolean isInitialized() {
+            byte isInitialized = memoizedIsInitialized;
+            if (isInitialized != -1) return isInitialized == 1;
+
+            if (!hasAccessible()) {
+                memoizedIsInitialized = 0;
+                return false;
+            }
+            memoizedIsInitialized = 1;
+            return true;
+        }
+
+        public void writeTo(com.google.protobuf.CodedOutputStream output)
+                throws java.io.IOException {
+            getSerializedSize();
+            if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                output.writeBool(1, accessible_);
+            }
+            getUnknownFields().writeTo(output);
+        }
+
+        public int getSerializedSize() {
+            int size = memoizedSerializedSize;
+            if (size != -1) return size;
+
+            size = 0;
+            if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                size += com.google.protobuf.CodedOutputStream
+                        .computeBoolSize(1, accessible_);
+            }
+            size += getUnknownFields().getSerializedSize();
+            memoizedSerializedSize = size;
+            return size;
+        }
+
+        @java.lang.Override
+        protected java.lang.Object writeReplace()
+                throws java.io.ObjectStreamException {
+            return super.writeReplace();
+        }
+
+        @java.lang.Override
+        public boolean equals(final java.lang.Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (!(obj instanceof org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse)) {
+                return super.equals(obj);
+            }
+            org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse other = (org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse) obj;
+
+            boolean result = true;
+            result = result && (hasAccessible() == other.hasAccessible());
+            if (hasAccessible()) {
+                result = result && (getAccessible()
+                        == other.getAccessible());
+            }
+            result = result &&
+                    getUnknownFields().equals(other.getUnknownFields());
+            return result;
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+            if (memoizedHashCode != 0) {
+                return memoizedHashCode;
+            }
+            int hash = 41;
+            hash = (19 * hash) + getDescriptorForType().hashCode();
+            if (hasAccessible()) {
+                hash = (37 * hash) + ACCESSIBLE_FIELD_NUMBER;
+                hash = (53 * hash) + hashBoolean(getAccessible());
+            }
+            hash = (29 * hash) + getUnknownFields().hashCode();
+            memoizedHashCode = hash;
+            return hash;
+        }
+
+        public Builder newBuilderForType() {
+            return newBuilder();
+        }
+
+        public Builder toBuilder() {
+            return newBuilder(this);
+        }
+
+        @java.lang.Override
+        protected Builder newBuilderForType(
+                com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            Builder builder = new Builder(parent);
+            return builder;
+        }
+
+        /**
+         * Protobuf type {@code CheckResponse}
+         */
+        public static final class Builder extends
+                com.google.protobuf.GeneratedMessage.Builder<Builder>
+                implements org.apache.spark.sql.hbase.CheckDirProtos.CheckResponseOrBuilder {
+            private int bitField0_;
+            // required bool accessible = 1;
+            private boolean accessible_;
+
+            // Construct using org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.newBuilder()
+            private Builder() {
+                maybeForceBuilderInitialization();
+            }
+
+            private Builder(
+                    com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+                super(parent);
+                maybeForceBuilderInitialization();
+            }
+
+            public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+                return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_descriptor;
+            }
+
+            private static Builder create() {
+                return new Builder();
+            }
+
+            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+                return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_fieldAccessorTable
+                        .ensureFieldAccessorsInitialized(
+                                org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.class, org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.Builder.class);
+            }
+
+            private void maybeForceBuilderInitialization() {
+                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+                }
+            }
+
+            public Builder clear() {
+                super.clear();
+                accessible_ = false;
+                bitField0_ = (bitField0_ & ~0x00000001);
+                return this;
+            }
+
+            public Builder clone() {
+                return create().mergeFrom(buildPartial());
+            }
+
+            public com.google.protobuf.Descriptors.Descriptor
             getDescriptorForType() {
-          return getDescriptor();
+                return org.apache.spark.sql.hbase.CheckDirProtos.internal_static_CheckResponse_descriptor;
+            }
+
+            public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse getDefaultInstanceForType() {
+                return org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance();
+            }
+
+            public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse build() {
+                org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse result = buildPartial();
+                if (!result.isInitialized()) {
+                    throw newUninitializedMessageException(result);
+                }
+                return result;
+            }
+
+            public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse buildPartial() {
+                org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse result = new org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse(this);
+                int from_bitField0_ = bitField0_;
+                int to_bitField0_ = 0;
+                if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+                    to_bitField0_ |= 0x00000001;
+                }
+                result.accessible_ = accessible_;
+                result.bitField0_ = to_bitField0_;
+                onBuilt();
+                return result;
+            }
+
+            public Builder mergeFrom(com.google.protobuf.Message other) {
+                if (other instanceof org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse) {
+                    return mergeFrom((org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse) other);
+                } else {
+                    super.mergeFrom(other);
+                    return this;
+                }
+            }
+
+            public Builder mergeFrom(org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse other) {
+                if (other == org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance()) return this;
+                if (other.hasAccessible()) {
+                    setAccessible(other.getAccessible());
+                }
+                this.mergeUnknownFields(other.getUnknownFields());
+                return this;
+            }
+
+            public final boolean isInitialized() {
+                if (!hasAccessible()) {
+
+                    return false;
+                }
+                return true;
+            }
+
+            public Builder mergeFrom(
+                    com.google.protobuf.CodedInputStream input,
+                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                    throws java.io.IOException {
+                org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse parsedMessage = null;
+                try {
+                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                    parsedMessage = (org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse) e.getUnfinishedMessage();
+                    throw e;
+                } finally {
+                    if (parsedMessage != null) {
+                        mergeFrom(parsedMessage);
+                    }
+                }
+                return this;
+            }
+
+            /**
+             * <code>required bool accessible = 1;</code>
+             */
+            public boolean hasAccessible() {
+                return ((bitField0_ & 0x00000001) == 0x00000001);
+            }
+
+            /**
+             * <code>required bool accessible = 1;</code>
+             */
+            public boolean getAccessible() {
+                return accessible_;
+            }
+
+            /**
+             * <code>required bool accessible = 1;</code>
+             */
+            public Builder setAccessible(boolean value) {
+                bitField0_ |= 0x00000001;
+                accessible_ = value;
+                onChanged();
+                return this;
+            }
+
+            /**
+             * <code>required bool accessible = 1;</code>
+             */
+            public Builder clearAccessible() {
+                bitField0_ = (bitField0_ & ~0x00000001);
+                accessible_ = false;
+                onChanged();
+                return this;
+            }
+
+            // @@protoc_insertion_point(builder_scope:CheckResponse)
         }
 
-        public final com.google.protobuf.Message callBlockingMethod(
-            com.google.protobuf.Descriptors.MethodDescriptor method,
-            com.google.protobuf.RpcController controller,
-            com.google.protobuf.Message request)
-            throws com.google.protobuf.ServiceException {
-          if (method.getService() != getDescriptor()) {
-            throw new java.lang.IllegalArgumentException(
-              "Service.callBlockingMethod() given method descriptor for " +
-              "wrong service type.");
-          }
-          switch(method.getIndex()) {
-            case 0:
-              return impl.getCheckResult(controller, (org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest)request);
-            default:
-              throw new java.lang.AssertionError("Can't get here.");
-          }
-        }
-
-        public final com.google.protobuf.Message
-            getRequestPrototype(
-            com.google.protobuf.Descriptors.MethodDescriptor method) {
-          if (method.getService() != getDescriptor()) {
-            throw new java.lang.IllegalArgumentException(
-              "Service.getRequestPrototype() given method " +
-              "descriptor for wrong service type.");
-          }
-          switch(method.getIndex()) {
-            case 0:
-              return org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.getDefaultInstance();
-            default:
-              throw new java.lang.AssertionError("Can't get here.");
-          }
-        }
-
-        public final com.google.protobuf.Message
-            getResponsePrototype(
-            com.google.protobuf.Descriptors.MethodDescriptor method) {
-          if (method.getService() != getDescriptor()) {
-            throw new java.lang.IllegalArgumentException(
-              "Service.getResponsePrototype() given method " +
-              "descriptor for wrong service type.");
-          }
-          switch(method.getIndex()) {
-            case 0:
-              return org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance();
-            default:
-              throw new java.lang.AssertionError("Can't get here.");
-          }
-        }
-
-      };
+        // @@protoc_insertion_point(class_scope:CheckResponse)
     }
 
     /**
-     * <code>rpc getCheckResult(.CheckRequest) returns (.CheckResponse);</code>
+     * Protobuf service {@code CheckDirService}
      */
-    public abstract void getCheckResult(
-        com.google.protobuf.RpcController controller,
-        org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request,
-        com.google.protobuf.RpcCallback<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse> done);
-
-    public static final
-        com.google.protobuf.Descriptors.ServiceDescriptor
-        getDescriptor() {
-      return org.apache.spark.sql.hbase.CheckDirProtos.getDescriptor().getServices().get(0);
-    }
-    public final com.google.protobuf.Descriptors.ServiceDescriptor
-        getDescriptorForType() {
-      return getDescriptor();
-    }
-
-    public final void callMethod(
-        com.google.protobuf.Descriptors.MethodDescriptor method,
-        com.google.protobuf.RpcController controller,
-        com.google.protobuf.Message request,
-        com.google.protobuf.RpcCallback<
-          com.google.protobuf.Message> done) {
-      if (method.getService() != getDescriptor()) {
-        throw new java.lang.IllegalArgumentException(
-          "Service.callMethod() given method descriptor for wrong " +
-          "service type.");
-      }
-      switch(method.getIndex()) {
-        case 0:
-          this.getCheckResult(controller, (org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest)request,
-            com.google.protobuf.RpcUtil.<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse>specializeCallback(
-              done));
-          return;
-        default:
-          throw new java.lang.AssertionError("Can't get here.");
-      }
-    }
-
-    public final com.google.protobuf.Message
-        getRequestPrototype(
-        com.google.protobuf.Descriptors.MethodDescriptor method) {
-      if (method.getService() != getDescriptor()) {
-        throw new java.lang.IllegalArgumentException(
-          "Service.getRequestPrototype() given method " +
-          "descriptor for wrong service type.");
-      }
-      switch(method.getIndex()) {
-        case 0:
-          return org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.getDefaultInstance();
-        default:
-          throw new java.lang.AssertionError("Can't get here.");
-      }
-    }
-
-    public final com.google.protobuf.Message
-        getResponsePrototype(
-        com.google.protobuf.Descriptors.MethodDescriptor method) {
-      if (method.getService() != getDescriptor()) {
-        throw new java.lang.IllegalArgumentException(
-          "Service.getResponsePrototype() given method " +
-          "descriptor for wrong service type.");
-      }
-      switch(method.getIndex()) {
-        case 0:
-          return org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance();
-        default:
-          throw new java.lang.AssertionError("Can't get here.");
-      }
-    }
-
-    public static Stub newStub(
-        com.google.protobuf.RpcChannel channel) {
-      return new Stub(channel);
-    }
-
-    public static final class Stub extends org.apache.spark.sql.hbase.CheckDirProtos.CheckDirService implements Interface {
-      private Stub(com.google.protobuf.RpcChannel channel) {
-        this.channel = channel;
-      }
-
-      private final com.google.protobuf.RpcChannel channel;
-
-      public com.google.protobuf.RpcChannel getChannel() {
-        return channel;
-      }
-
-      public  void getCheckResult(
-          com.google.protobuf.RpcController controller,
-          org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request,
-          com.google.protobuf.RpcCallback<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse> done) {
-        channel.callMethod(
-          getDescriptor().getMethods().get(0),
-          controller,
-          request,
-          org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance(),
-          com.google.protobuf.RpcUtil.generalizeCallback(
-            done,
-            org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.class,
-            org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance()));
-      }
-    }
-
-    public static BlockingInterface newBlockingStub(
-        com.google.protobuf.BlockingRpcChannel channel) {
-      return new BlockingStub(channel);
-    }
-
-    public interface BlockingInterface {
-      public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse getCheckResult(
-          com.google.protobuf.RpcController controller,
-          org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request)
-          throws com.google.protobuf.ServiceException;
-    }
-
-    private static final class BlockingStub implements BlockingInterface {
-      private BlockingStub(com.google.protobuf.BlockingRpcChannel channel) {
-        this.channel = channel;
-      }
-
-      private final com.google.protobuf.BlockingRpcChannel channel;
-
-      public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse getCheckResult(
-          com.google.protobuf.RpcController controller,
-          org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request)
-          throws com.google.protobuf.ServiceException {
-        return (org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse) channel.callBlockingMethod(
-          getDescriptor().getMethods().get(0),
-          controller,
-          request,
-          org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance());
-      }
-
-    }
-
-    // @@protoc_insertion_point(class_scope:CheckDirService)
-  }
-
-  private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_CheckRequest_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_CheckRequest_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_CheckResponse_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_CheckResponse_fieldAccessorTable;
-
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
-    return descriptor;
-  }
-  private static com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
-  static {
-    java.lang.String[] descriptorData = {
-      "\n\025CheckDirService.proto\"\016\n\014CheckRequest\"" +
-      "#\n\rCheckResponse\022\022\n\naccessible\030\001 \002(\0102B\n\017" +
-      "CheckDirService\022/\n\016getCheckResult\022\r.Chec" +
-      "kRequest\032\016.CheckResponseB4\n\032org.apache.s" +
-      "park.sql.hbaseB\016CheckDirProtosH\001\210\001\001\240\001\001"
-    };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-        public com.google.protobuf.ExtensionRegistry assignDescriptors(
-            com.google.protobuf.Descriptors.FileDescriptor root) {
-          descriptor = root;
-          internal_static_CheckRequest_descriptor =
-            getDescriptor().getMessageTypes().get(0);
-          internal_static_CheckRequest_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_CheckRequest_descriptor,
-              new java.lang.String[] { });
-          internal_static_CheckResponse_descriptor =
-            getDescriptor().getMessageTypes().get(1);
-          internal_static_CheckResponse_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_CheckResponse_descriptor,
-              new java.lang.String[] { "Accessible", });
-          return null;
+    public static abstract class CheckDirService
+            implements com.google.protobuf.Service {
+        protected CheckDirService() {
         }
-      };
-    com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
-  }
 
-  // @@protoc_insertion_point(outer_class_scope)
+        public static com.google.protobuf.Service newReflectiveService(
+                final Interface impl) {
+            return new CheckDirService() {
+                @java.lang.Override
+                public void getCheckResult(
+                        com.google.protobuf.RpcController controller,
+                        org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request,
+                        com.google.protobuf.RpcCallback<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse> done) {
+                    impl.getCheckResult(controller, request, done);
+                }
+
+            };
+        }
+
+        public static com.google.protobuf.BlockingService
+        newReflectiveBlockingService(final BlockingInterface impl) {
+            return new com.google.protobuf.BlockingService() {
+                public final com.google.protobuf.Descriptors.ServiceDescriptor
+                getDescriptorForType() {
+                    return getDescriptor();
+                }
+
+                public final com.google.protobuf.Message callBlockingMethod(
+                        com.google.protobuf.Descriptors.MethodDescriptor method,
+                        com.google.protobuf.RpcController controller,
+                        com.google.protobuf.Message request)
+                        throws com.google.protobuf.ServiceException {
+                    if (method.getService() != getDescriptor()) {
+                        throw new java.lang.IllegalArgumentException(
+                                "Service.callBlockingMethod() given method descriptor for " +
+                                        "wrong service type.");
+                    }
+                    switch (method.getIndex()) {
+                        case 0:
+                            return impl.getCheckResult(controller, (org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest) request);
+                        default:
+                            throw new java.lang.AssertionError("Can't get here.");
+                    }
+                }
+
+                public final com.google.protobuf.Message
+                getRequestPrototype(
+                        com.google.protobuf.Descriptors.MethodDescriptor method) {
+                    if (method.getService() != getDescriptor()) {
+                        throw new java.lang.IllegalArgumentException(
+                                "Service.getRequestPrototype() given method " +
+                                        "descriptor for wrong service type.");
+                    }
+                    switch (method.getIndex()) {
+                        case 0:
+                            return org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.getDefaultInstance();
+                        default:
+                            throw new java.lang.AssertionError("Can't get here.");
+                    }
+                }
+
+                public final com.google.protobuf.Message
+                getResponsePrototype(
+                        com.google.protobuf.Descriptors.MethodDescriptor method) {
+                    if (method.getService() != getDescriptor()) {
+                        throw new java.lang.IllegalArgumentException(
+                                "Service.getResponsePrototype() given method " +
+                                        "descriptor for wrong service type.");
+                    }
+                    switch (method.getIndex()) {
+                        case 0:
+                            return org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance();
+                        default:
+                            throw new java.lang.AssertionError("Can't get here.");
+                    }
+                }
+
+            };
+        }
+
+        public static final com.google.protobuf.Descriptors.ServiceDescriptor
+        getDescriptor() {
+            return org.apache.spark.sql.hbase.CheckDirProtos.getDescriptor().getServices().get(0);
+        }
+
+        public static Stub newStub(
+                com.google.protobuf.RpcChannel channel) {
+            return new Stub(channel);
+        }
+
+        public static BlockingInterface newBlockingStub(
+                com.google.protobuf.BlockingRpcChannel channel) {
+            return new BlockingStub(channel);
+        }
+
+        /**
+         * <code>rpc getCheckResult(.CheckRequest) returns (.CheckResponse);</code>
+         */
+        public abstract void getCheckResult(
+                com.google.protobuf.RpcController controller,
+                org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request,
+                com.google.protobuf.RpcCallback<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse> done);
+
+        public final com.google.protobuf.Descriptors.ServiceDescriptor
+        getDescriptorForType() {
+            return getDescriptor();
+        }
+
+        public final void callMethod(
+                com.google.protobuf.Descriptors.MethodDescriptor method,
+                com.google.protobuf.RpcController controller,
+                com.google.protobuf.Message request,
+                com.google.protobuf.RpcCallback<
+                        com.google.protobuf.Message> done) {
+            if (method.getService() != getDescriptor()) {
+                throw new java.lang.IllegalArgumentException(
+                        "Service.callMethod() given method descriptor for wrong " +
+                                "service type.");
+            }
+            switch (method.getIndex()) {
+                case 0:
+                    this.getCheckResult(controller, (org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest) request,
+                            com.google.protobuf.RpcUtil.<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse>specializeCallback(
+                                    done));
+                    return;
+                default:
+                    throw new java.lang.AssertionError("Can't get here.");
+            }
+        }
+
+        public final com.google.protobuf.Message
+        getRequestPrototype(
+                com.google.protobuf.Descriptors.MethodDescriptor method) {
+            if (method.getService() != getDescriptor()) {
+                throw new java.lang.IllegalArgumentException(
+                        "Service.getRequestPrototype() given method " +
+                                "descriptor for wrong service type.");
+            }
+            switch (method.getIndex()) {
+                case 0:
+                    return org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest.getDefaultInstance();
+                default:
+                    throw new java.lang.AssertionError("Can't get here.");
+            }
+        }
+
+        public final com.google.protobuf.Message
+        getResponsePrototype(
+                com.google.protobuf.Descriptors.MethodDescriptor method) {
+            if (method.getService() != getDescriptor()) {
+                throw new java.lang.IllegalArgumentException(
+                        "Service.getResponsePrototype() given method " +
+                                "descriptor for wrong service type.");
+            }
+            switch (method.getIndex()) {
+                case 0:
+                    return org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance();
+                default:
+                    throw new java.lang.AssertionError("Can't get here.");
+            }
+        }
+
+        public interface Interface {
+            /**
+             * <code>rpc getCheckResult(.CheckRequest) returns (.CheckResponse);</code>
+             */
+            public abstract void getCheckResult(
+                    com.google.protobuf.RpcController controller,
+                    org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request,
+                    com.google.protobuf.RpcCallback<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse> done);
+
+        }
+
+        public interface BlockingInterface {
+            public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse getCheckResult(
+                    com.google.protobuf.RpcController controller,
+                    org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request)
+                    throws com.google.protobuf.ServiceException;
+        }
+
+        public static final class Stub extends org.apache.spark.sql.hbase.CheckDirProtos.CheckDirService implements Interface {
+            private final com.google.protobuf.RpcChannel channel;
+
+            private Stub(com.google.protobuf.RpcChannel channel) {
+                this.channel = channel;
+            }
+
+            public com.google.protobuf.RpcChannel getChannel() {
+                return channel;
+            }
+
+            public void getCheckResult(
+                    com.google.protobuf.RpcController controller,
+                    org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request,
+                    com.google.protobuf.RpcCallback<org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse> done) {
+                channel.callMethod(
+                        getDescriptor().getMethods().get(0),
+                        controller,
+                        request,
+                        org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance(),
+                        com.google.protobuf.RpcUtil.generalizeCallback(
+                                done,
+                                org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.class,
+                                org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance()));
+            }
+        }
+
+        private static final class BlockingStub implements BlockingInterface {
+            private final com.google.protobuf.BlockingRpcChannel channel;
+
+            private BlockingStub(com.google.protobuf.BlockingRpcChannel channel) {
+                this.channel = channel;
+            }
+
+            public org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse getCheckResult(
+                    com.google.protobuf.RpcController controller,
+                    org.apache.spark.sql.hbase.CheckDirProtos.CheckRequest request)
+                    throws com.google.protobuf.ServiceException {
+                return (org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse) channel.callBlockingMethod(
+                        getDescriptor().getMethods().get(0),
+                        controller,
+                        request,
+                        org.apache.spark.sql.hbase.CheckDirProtos.CheckResponse.getDefaultInstance());
+            }
+
+        }
+
+        // @@protoc_insertion_point(class_scope:CheckDirService)
+    }
+
+    // @@protoc_insertion_point(outer_class_scope)
 }

--- a/src/main/scala/org/apache/spark/sql/hbase/HBaseCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/HBaseCatalog.scala
@@ -173,7 +173,9 @@ private[hbase] class HBaseCatalog(@transient hbaseContext: SQLContext,
   def createTable(tableName: String, hbaseNamespace: String, hbaseTableName: String,
                   allColumns: Seq[AbstractColumn], splitKeys: Array[Array[Byte]],
                   separators: Array[Byte],
-                  encodingFormat: String, hiveStorage: Boolean = false): HBaseRelation = {
+                  encodingFormat: String,
+                  keyFactory: KeyFactory,
+                  hiveStorage: Boolean = false): HBaseRelation = {
 
     // create a new hbase table for the user if not exist
     val nonKeyColumns = allColumns.filter(_.isInstanceOf[NonKeyColumn])
@@ -193,7 +195,7 @@ private[hbase] class HBaseCatalog(@transient hbaseContext: SQLContext,
     }
 
     val hbaseRelation = HBaseRelation(tableName, hbaseNamespace, hbaseTableName,
-      allColumns, deploySuccessfully, separators, encodingFormat, hiveStorage)(hbaseContext)
+      allColumns, deploySuccessfully, separators, encodingFormat, keyFactory, hiveStorage)(hbaseContext)
     hbaseRelation.setConfig(configuration)
     hbaseRelation.fetchPartitions()
     hbaseRelation

--- a/src/main/scala/org/apache/spark/sql/hbase/HBaseCriticalPoint.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/HBaseCriticalPoint.scala
@@ -296,7 +296,8 @@ object RangeCriticalPoint {
    * @return a list of generated critical point ranges
    */
   private[hbase] def generateCriticalPointRange[T](cps: Seq[CriticalPoint[T]],
-                                                   dimIndex: Int, dt: AtomicType)
+                                                   dimIndex: Int, dt: AtomicType,
+                                                   relation: HBaseRelation)
   : Seq[CriticalPointRange[T]] = {
     if (cps.isEmpty) Nil
     else {
@@ -369,7 +370,8 @@ object RangeCriticalPoint {
         }
       }
       // remove any redundant ranges for integral type
-      if (discreteType) {
+      if (discreteType && !relation.fieldReadersMap.get(dt.asInstanceOf[DataType]).
+        getDataStorageFormat.equals(FieldFactory.STRING_FORMAT)) {
         result.map(r => {
           var gotNew = false
           val numeric = dt.asInstanceOf[IntegralType]
@@ -444,7 +446,7 @@ object RangeCriticalPoint {
     if (criticalPoints.isEmpty) (false, Nil)
     else {
       val cpRanges: Seq[CriticalPointRange[dt.InternalType]]
-      = generateCriticalPointRange[dt.InternalType](criticalPoints, dimIndex, dt)
+      = generateCriticalPointRange[dt.InternalType](criticalPoints, dimIndex, dt, relation)
       // Step 1.2
       val keyIndex = predRefs.indexWhere(_.exprId == relation.partitionKeys(dimIndex).exprId)
       val qualifiedCPRanges = cpRanges.filter(cpr => {

--- a/src/main/scala/org/apache/spark/sql/hbase/HBaseCustomFilter.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/HBaseCustomFilter.scala
@@ -445,7 +445,9 @@ private[hbase] class HBaseCustomFilter extends FilterBase with Writable {
     var canAddOne: Boolean = true
     val fieldData = relation.fieldReadersMap.get(dt)
     if (dt == StringType || dt == DecimalType) {
-      val newString = HBaseKVHelper.addOneString(fieldData.getRawBytes(value.asInstanceOf[fieldData.InternalType]))
+      val newString = HBaseKVHelper.addOneString(
+        fieldData.getRawBytes(value.asInstanceOf[fieldData.InternalType]),
+        relation.keyFactory.delimiter)
       val newValue = fieldData.getValueFromBytes(newString, 0, newString.length)
       node.currentValue = newValue
     } else {
@@ -496,7 +498,7 @@ private[hbase] class HBaseCustomFilter extends FilterBase with Writable {
       }
       node = levelNode
     }
-    HBaseKVHelper.encodingRawKeyColumns(list.toSeq)
+    relation.keyFactory.encodingRawKeyColumns(list.toSeq)
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/hbase/HBaseCustomFilter.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/HBaseCustomFilter.scala
@@ -536,7 +536,7 @@ private[hbase] class HBaseCustomFilter extends FilterBase with Writable {
       val qualifiedCPRanges = if (criticalPoints.nonEmpty) {
         // partial reduce
         val cpRanges: Seq[CriticalPointRange[t]] =
-          RangeCriticalPoint.generateCriticalPointRange(criticalPoints, dimIndex, dt)
+          RangeCriticalPoint.generateCriticalPointRange(criticalPoints, dimIndex, dt, relation)
 
         // set values for all more significant dimensions
         var parent: Node = node

--- a/src/main/scala/org/apache/spark/sql/hbase/HBaseRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/HBaseRelation.scala
@@ -1110,7 +1110,7 @@ private[sql] case class HBaseRelation(
       if (curKeyIndex >= keyColumns.length) origRowKey
       else {
         val typeOfKey = keyColumns(curKeyIndex)
-        if (typeOfKey.dataType == StringType) {
+        if (typeOfKey.dataType == StringType || encodingFormat.equals(FieldFactory.STRING_FORMAT)) {
           val indexOfStringEnd = origRowKey.indexOf(keyFactory.delimiter, rowIndex)
           if (indexOfStringEnd == -1) {
             val nOfUTF8StrBytes = HBaseRelation.numOfBytes(origRowKey(rowIndex))

--- a/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLContext.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLContext.scala
@@ -23,10 +23,10 @@ import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, OverrideCatalog}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-import org.apache.spark.sql.execution.{EnsureRowFormats, EnsureRequirements, SparkPlan}
+import org.apache.spark.sql.execution.{EnsureRequirements, EnsureRowFormats, SparkPlan}
 import org.apache.spark.sql.hbase.catalyst.analysis.ReplaceOutput
 import org.apache.spark.sql.hbase.execution.{AddCoprocessor, HBaseStrategies}
-import org.apache.spark.sql.hive.{HBaseConversions, HiveContext}
+import org.apache.spark.sql.hive.{HBaseHiveCatalog, HiveContext}
 
 class HBaseSQLContext(sc: SparkContext) extends HiveContext(sc) {
   self =>
@@ -42,10 +42,12 @@ class HBaseSQLContext(sc: SparkContext) extends HiveContext(sc) {
   protected[sql] lazy val hbaseCatalog: HBaseCatalog =
     new HBaseCatalog(this, sc.hadoopConfiguration) with OverrideCatalog
 
+  override lazy val catalog = new HBaseHiveCatalog(metadataHive, this) with OverrideCatalog
+
   @transient
   override protected[sql] lazy val analyzer: Analyzer =
     new Analyzer(catalog, functionRegistry, conf) {
-      override val extendedResolutionRules = ReplaceOutput :: HBaseConversions(self) :: Nil
+      override val extendedResolutionRules = ReplaceOutput :: Nil
     }
 
   experimental.extraStrategies = Seq((new SparkPlanner with HBaseStrategies).HBaseDataSource)

--- a/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLReaderRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLReaderRDD.scala
@@ -143,7 +143,7 @@ class HBaseSQLReaderRDD(val relation: HBaseRelation,
     if (list.isEmpty) {
       null
     } else {
-      HBaseKVHelper.encodingRawKeyColumns(list)
+      relation.keyFactory.encodingRawKeyColumns(list)
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/hbase/dataTypeReadWriteObjects.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/dataTypeReadWriteObjects.scala
@@ -34,13 +34,14 @@ object FieldFactory {
   val BINARY_FORMAT = "binaryformat"
   val STRING_FORMAT = "stringformat"
   val HBASE_FORMAT = "hbaseformat"
-  val COLLECTION_SEPERATOR = "collectionSeperator"
-  val MAPKEY_SEPERATOR = "mapkeySeperator"
+  val KEY_SEPARATOR = "keySeparator"
+  val COLLECTION_SEPARATOR = "collectionSeparator"
+  val MAPKEY_SEPARATOR = "mapkeySeparator"
 
   def collectSeperators(parameters: Map[String, String]) = {
     val separatorCandidates: ArrayBuffer[Byte] = new ArrayBuffer[Byte]()
-    separatorCandidates += getByte(parameters.getOrElse(FieldFactory.COLLECTION_SEPERATOR, null), 2.toByte)
-    separatorCandidates += getByte(parameters.getOrElse(FieldFactory.MAPKEY_SEPERATOR, null), 3.toByte)
+    separatorCandidates += getByte(parameters.getOrElse(FieldFactory.COLLECTION_SEPARATOR, null), 2.toByte)
+    separatorCandidates += getByte(parameters.getOrElse(FieldFactory.MAPKEY_SEPARATOR, null), 3.toByte)
 
     //use only control chars that are very unlikely to be part of the string
     // the following might/likely to be used in text files for strings

--- a/src/main/scala/org/apache/spark/sql/hbase/execution/hbaseCommands.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/execution/hbaseCommands.scala
@@ -498,7 +498,7 @@ case class BulkLoadIntoTableCommand(
             }
           }
           if (HBaseKVHelper.string2KV(values.toSeq, relation, lineBuffer, keyBytes, valueBytes)) {
-            val rowKeyData = HBaseKVHelper.encodingRawKeyColumns(keyBytes)
+            val rowKeyData = relation.keyFactory.encodingRawKeyColumns(keyBytes)
             Seq((rowKeyData, valueBytes))
           } else {
             if (skipCount == 100) {

--- a/src/main/scala/org/apache/spark/sql/hbase/keyFactory.scala
+++ b/src/main/scala/org/apache/spark/sql/hbase/keyFactory.scala
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hbase
+
+import org.apache.spark.sql.types.{AtomicType, DataType, DecimalType, StringType}
+
+/**
+ * This interface is responsible for encoding and decoding of row key
+ */
+abstract class KeyFactory extends Serializable {
+
+  val delimiter: Byte
+
+  /**
+   * create row key based on key columns information
+   * @param rawKeyColumns sequence of byte array and data type representing the key columns
+   * @return array of bytes
+   */
+  def encodingRawKeyColumns(rawKeyColumns: Seq[(HBaseRawType, DataType)]): HBaseRawType
+
+  /**
+   * generate the sequence information of key columns from the byte array
+   * @param rowKey array of bytes
+   * @param keyColumns the sequence of key columns
+   * @param keyLength rowkey length: specified if not negative
+   * @return sequence of information in (offset, length) tuple
+   */
+  def decodingRawKeyColumns(rowKey: HBaseRawType,
+                            keyColumns: Seq[KeyColumn],
+                            keyLength: Int = -1,
+                            startIndex: Int = 0): Seq[(Int, Int)]
+
+}
+
+class AstroKeyFactory extends KeyFactory {
+  val delimiter: Byte = 0
+
+  /**
+   * create row key based on key columns information
+   * for strings, it will add '0x00' as its delimiter
+   * @param rawKeyColumns sequence of byte array and data type representing the key columns
+   * @return array of bytes
+   */
+  def encodingRawKeyColumns(rawKeyColumns: Seq[(HBaseRawType, DataType)]): HBaseRawType = {
+    var length = 0
+    for (i <- 0 until rawKeyColumns.length) {
+      length += rawKeyColumns(i)._1.length
+      if ((rawKeyColumns(i)._2 == StringType ||
+        rawKeyColumns(i)._2 == DecimalType) &&
+        i < rawKeyColumns.length - 1) {
+        length += 1
+      }
+    }
+    val result = new HBaseRawType(length)
+    var index = 0
+    var kcIdx = 0
+    for (rawKeyColumn <- rawKeyColumns) {
+      Array.copy(rawKeyColumn._1, 0, result, index, rawKeyColumn._1.length)
+      index += rawKeyColumn._1.length
+      if ((rawKeyColumn._2 == StringType ||
+        rawKeyColumn._2 == DecimalType) &&
+        kcIdx < rawKeyColumns.length - 1) {
+        result(index) = delimiter
+        index += 1
+      }
+      kcIdx += 1
+    }
+    result
+  }
+
+  /**
+   * generate the sequence information of key columns from the byte array
+   * @param rowKey array of bytes
+   * @param keyColumns the sequence of key columns
+   * @param keyLength rowkey length: specified if not negative
+   * @return sequence of information in (offset, length) tuple
+   */
+  def decodingRawKeyColumns(rowKey: HBaseRawType,
+                            keyColumns: Seq[KeyColumn],
+                            keyLength: Int = -1,
+                            startIndex: Int = 0): Seq[(Int, Int)] = {
+    var index = startIndex
+    var pos = 0
+    val limit = if (keyLength < 0) {
+      rowKey.length
+    } else {
+      index + keyLength
+    }
+    keyColumns.map {
+      case c =>
+        if (index >= limit) (-1, -1)
+        else {
+          val offset = index
+          if (c.dataType == StringType || c.dataType == DecimalType) {
+            pos = rowKey.indexOf(delimiter, index)
+            if (pos == -1 || pos > limit) {
+              // this is at the last dimension
+              pos = limit
+            }
+            index = pos + 1
+            (offset, pos - offset)
+          } else {
+            val length = c.dataType.asInstanceOf[AtomicType].defaultSize
+            index += length
+            (offset, length)
+          }
+        }
+    }
+  }
+
+}
+
+class SimpleKeyFactory(val delimiter: Byte) extends KeyFactory {
+
+  /**
+   * create row key based on key columns information it will add delimiter as its delimiter
+   * @param rawKeyColumns sequence of byte array and data type representing the key columns
+   * @return array of bytes
+   */
+  def encodingRawKeyColumns(rawKeyColumns: Seq[(HBaseRawType, DataType)]): HBaseRawType = {
+    var length = 0
+    for (i <- 0 until rawKeyColumns.length) {
+      length += rawKeyColumns(i)._1.length
+      if (i < rawKeyColumns.length - 1) {
+        length += 1
+      }
+    }
+    val result = new HBaseRawType(length)
+    var index = 0
+    var kcIdx = 0
+    for (rawKeyColumn <- rawKeyColumns) {
+      Array.copy(rawKeyColumn._1, 0, result, index, rawKeyColumn._1.length)
+      index += rawKeyColumn._1.length
+      if (kcIdx < rawKeyColumns.length - 1) {
+        result(index) = delimiter
+        index += 1
+      }
+      kcIdx += 1
+    }
+    result
+  }
+
+  /**
+   * generate the sequence information of key columns from the byte array
+   * @param rowKey array of bytes
+   * @param keyColumns the sequence of key columns
+   * @param keyLength rowkey length: specified if not negative
+   * @return sequence of information in (offset, length) tuple
+   */
+  def decodingRawKeyColumns(rowKey: HBaseRawType,
+                            keyColumns: Seq[KeyColumn],
+                            keyLength: Int = -1,
+                            startIndex: Int = 0): Seq[(Int, Int)] = {
+    var index = startIndex
+    var pos = 0
+    val limit = if (keyLength < 0) {
+      rowKey.length
+    } else {
+      index + keyLength
+    }
+    keyColumns.map {
+      case c =>
+        if (index >= limit) (-1, -1)
+        else {
+          val offset = index
+          pos = rowKey.indexOf(delimiter, index)
+          if (pos == -1 || pos > limit) {
+            // this is at the last dimension
+            pos = limit
+          }
+          index = pos + 1
+          (offset, pos - offset)
+        }
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/hive/HBaseConversions.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/HBaseConversions.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Subquery}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.hbase._
+import org.apache.spark.sql.hive.client.ClientInterface
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
@@ -80,23 +81,36 @@ case class HBaseConversions(sqlContext: SQLContext) extends Rule[LogicalPlan] {
     var keyCounter = 0
     val allColumns = new ArrayBuffer[AbstractColumn]()
     var extraParams = Map[String, String]()
-    extraParams += FieldFactory.COLLECTION_SEPERATOR -> mr.tableDesc.getProperties.getProperty("colelction.delim")
-    extraParams += FieldFactory.MAPKEY_SEPERATOR -> mr.tableDesc.getProperties.getProperty("mapkey.delim")
+    extraParams += FieldFactory.COLLECTION_SEPARATOR -> mr.tableDesc.getProperties.getProperty("colelction.delim")
+    extraParams += FieldFactory.MAPKEY_SEPARATOR -> mr.tableDesc.getProperties.getProperty("mapkey.delim")
     val separators = FieldFactory.collectSeperators(extraParams)
     val encodingFormat = {
-      if(storageFormat != null && storageFormat.equals("binary"))
+      if (storageFormat != null && storageFormat.equals("binary"))
         FieldFactory.HBASE_FORMAT
       else
         FieldFactory.STRING_FORMAT
     }
+    val keyFactory = new SimpleKeyFactory(
+      mr.tableDesc.getProperties.getProperty("colelction.delim").toCharArray()(0).toByte)
     //Create Astro columns from Hive table columns
     mr.hiveQlTable.getAllCols.foreach { f =>
       colMapIter.hasNext
       val col = colMapIter.next()
       if (col.isHbaseRowKey) {
         //Currently not supported the complex key types in Astro
-        if (f.getType.startsWith("struct<") || f.getType.startsWith("array<") || f.getType.startsWith("map<")) {
+        if (f.getType.startsWith("array<") || f.getType.startsWith("map<")) {
           throw new Exception(s"Key column type should not be complex data type.")
+        } else if (f.getType.startsWith("struct<")) {
+          f.getType.stripPrefix("struct<").dropRight(1).split(",").map { fs =>
+            val strings = fs.split(":")
+            allColumns += KeyColumn(
+              strings(0),
+              catalog.getDataType(strings(1)),
+              keyCounter,
+              FieldFactory.createFieldData(catalog.getDataType(strings(1)), encodingFormat, separators, 0, true)
+            )
+            keyCounter = keyCounter + 1
+          }
         } else {
           allColumns += KeyColumn(
             f.getName,
@@ -118,8 +132,98 @@ case class HBaseConversions(sqlContext: SQLContext) extends Rule[LogicalPlan] {
     }
     //Create HbaseRelation with parsed columns from Hive table.
     LogicalRelation(catalog.createTable(mr.hiveQlTable.getTableName, "",
-                    hbaseTableName,
-                    allColumns, null, separators, encodingFormat, true))
+      hbaseTableName,
+      allColumns, null, separators, encodingFormat, keyFactory, false))
+  }
+
+}
+
+/**
+ * This catalog extends HiveMetastoreCatalog and updates the relation if it has storage handler of type Hbase.
+ * Right now this is work around as we are not yet supporting complex datatypes on key columns. Once we support complex
+ * datatypes on key we can move to above class HBaseConversions.
+ * @param client
+ * @param hbaseContext
+ */
+class HBaseHiveCatalog(client: ClientInterface, hbaseContext: HBaseSQLContext)
+  extends HiveMetastoreCatalog(client, hbaseContext) {
+
+  private lazy val catalog = hbaseContext.hbaseCatalog
+
+  override def lookupRelation(tableIdentifier: Seq[String],
+                              alias: Option[String]): LogicalPlan = {
+    val relation = super.lookupRelation(tableIdentifier, alias)
+    relation match {
+      case mr: MetastoreRelation
+        if mr.tableDesc.getSerdeClassName.toLowerCase.contains("hbase") =>
+        convertToHBaseRelation(mr)
+      case _ => relation
+    }
+  }
+
+  def convertToHBaseRelation(mr: MetastoreRelation): LogicalRelation = {
+    val columnsMapping = mr.hiveQlTable.getSerdeParam(HBaseSerDe.HBASE_COLUMNS_MAPPING)
+    val storageFormat = mr.hiveQlTable.getSerdeParam(HBaseSerDe.HBASE_TABLE_DEFAULT_STORAGE_TYPE)
+    val hbaseTableName = mr.hiveQlTable.getProperty("hbase.table.name")
+
+    val colMap = HBaseSerDe.parseColumnsMapping(columnsMapping)
+    val colMapIter = colMap.iterator()
+    var keyCounter = 0
+    val allColumns = new ArrayBuffer[AbstractColumn]()
+    var extraParams = Map[String, String]()
+    extraParams += FieldFactory.COLLECTION_SEPARATOR -> mr.tableDesc.getProperties.getProperty("colelction.delim")
+    extraParams += FieldFactory.MAPKEY_SEPARATOR -> mr.tableDesc.getProperties.getProperty("mapkey.delim")
+    val separators = FieldFactory.collectSeperators(extraParams)
+    val encodingFormat = {
+      if (storageFormat != null && storageFormat.equals("binary"))
+        FieldFactory.HBASE_FORMAT
+      else
+        FieldFactory.STRING_FORMAT
+    }
+    val keyFactory = new SimpleKeyFactory(
+      mr.tableDesc.getProperties.getProperty("colelction.delim").toCharArray()(0).toByte)
+    //Create Astro columns from Hive table columns
+    mr.hiveQlTable.getAllCols.foreach { f =>
+      colMapIter.hasNext
+      val col = colMapIter.next()
+      if (col.isHbaseRowKey) {
+        //Currently not supported the complex key types in Astro
+        if (f.getType.startsWith("array<") || f.getType.startsWith("map<")) {
+          throw new Exception(s"Key column type should not be complex data type.")
+        } else if (f.getType.startsWith("struct<")) {
+          f.getType.stripPrefix("struct<").dropRight(1).split(",").map { fs =>
+            val strings = fs.split(":")
+            allColumns += KeyColumn(
+              strings(0),
+              catalog.getDataType(strings(1)),
+              keyCounter,
+              FieldFactory.createFieldData(catalog.getDataType(strings(1)), encodingFormat, separators, 0, true)
+            )
+            keyCounter = keyCounter + 1
+          }
+        } else {
+          allColumns += KeyColumn(
+            f.getName,
+            catalog.getDataType(f.getType),
+            keyCounter,
+            FieldFactory.createFieldData(catalog.getDataType(f.getType), encodingFormat, separators, 0, true)
+          )
+          keyCounter = keyCounter + 1
+        }
+      } else {
+        allColumns += NonKeyColumn(
+          f.getName,
+          catalog.getDataType(f.getType),
+          col.getFamilyName,
+          col.getQualifierName,
+          FieldFactory.createFieldData(catalog.getDataType(f.getType), encodingFormat, separators, 0, true)
+        )
+      }
+    }
+    //Create HbaseRelation with parsed columns from Hive table.
+    LogicalRelation(catalog.createTable(mr.hiveQlTable.getTableName, "",
+      hbaseTableName,
+      allColumns, null, separators, encodingFormat, keyFactory, false))
   }
 
 }

--- a/src/test/scala/org/apache/spark/sql/hbase/ComplexDataTypesTestSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hbase/ComplexDataTypesTestSuite.scala
@@ -56,8 +56,8 @@ class ComplexDataTypesTestSuite extends TestBaseWithNonSplitData {
          |  hbaseTableName "$TestHBaseTableDataTypesName",
          |  keyCols "doublecol, strcol, intcol",
          |  colsMapping "bytecol=cf1.hbytecol, shortcol=cf1.hshortcol, longcol=cf2.hlongcol, floatcol=cf2.hfloatcol,datecol=cf2.hdatecol,timestampcol=cf2.htimestampcol,arraycol=cf2.harraycol,structcol=cf2.hstructcol,mapcol=cf2.hmapcol,decicol=cf2.hdecicol",
-         |  collectionSeperator "~",
-         |  mapkeySeperator "&"
+         |  collectionSeparator "~",
+         |  mapkeySeparator "&"
          |)"""
         .stripMargin
     createTable(TestTableDataTypesName, TestHBaseTableDataTypesName, testTableCreationHiveSQL)

--- a/src/test/scala/org/apache/spark/sql/hbase/CriticalPointsTestSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hbase/CriticalPointsTestSuite.scala
@@ -356,27 +356,29 @@ class CriticalPointsTestSuite extends FunSuite with BeforeAndAfterAll with Loggi
 
     val fieldDataInteger = FieldFactory.createFieldData(IntegerType, FieldFactory.BINARY_FORMAT, Array[Byte]())
 
-    val rowkey0 = HBaseKVHelper.encodingRawKeyColumns(
+    val keyFactory = new AstroKeyFactory
+
+    val rowkey0 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(0.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(7.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey1 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey1 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(1.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey2 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey2 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey3 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey3 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(3.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(4.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey4 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey4 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(3.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(6.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
@@ -443,27 +445,29 @@ class CriticalPointsTestSuite extends FunSuite with BeforeAndAfterAll with Loggi
 
     val fieldDataInteger = FieldFactory.createFieldData(IntegerType, FieldFactory.BINARY_FORMAT, Array[Byte]())
 
-    val rowkey0 = HBaseKVHelper.encodingRawKeyColumns(
+    val keyFactory = new AstroKeyFactory
+
+    val rowkey0 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(1.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(1.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey1 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey1 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(8.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey2 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey2 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(32.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(16.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey3 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey3 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(64.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(128.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey4 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey4 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(1024.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(256.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
@@ -543,27 +547,29 @@ class CriticalPointsTestSuite extends FunSuite with BeforeAndAfterAll with Loggi
 
     val fieldDataInteger = FieldFactory.createFieldData(IntegerType, FieldFactory.BINARY_FORMAT, Array[Byte]())
 
-    val rowkey0 = HBaseKVHelper.encodingRawKeyColumns(
+    val keyFactory = new AstroKeyFactory
+
+    val rowkey0 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(1.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(1.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey1 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey1 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(8.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey2 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey2 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(32.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(16.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey3 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey3 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(64.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(128.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey4 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey4 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(1024.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(256.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
@@ -641,31 +647,33 @@ class CriticalPointsTestSuite extends FunSuite with BeforeAndAfterAll with Loggi
 
     val fieldDataInteger = FieldFactory.createFieldData(IntegerType, FieldFactory.BINARY_FORMAT, Array[Byte]())
 
-    val rowkey0 = HBaseKVHelper.encodingRawKeyColumns(
+    val keyFactory = new AstroKeyFactory
+
+    val rowkey0 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(8.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(16.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey1 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey1 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(8.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(32.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey2 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey2 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(8.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(64.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey3 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey3 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(8.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(128.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey4 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey4 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(8.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(256.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))

--- a/src/test/scala/org/apache/spark/sql/hbase/HBaseAdditionalQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hbase/HBaseAdditionalQuerySuite.scala
@@ -37,7 +37,7 @@ class HBaseAdditionalQuerySuite extends TestBase {
 
     def generateRowKey(keys: Array[Any], length: Int = -1) = {
       val completeRowKey = HBaseKVHelper.
-        makeRowKey(new GenericInternalRow(keys), types, FieldFactory.BINARY_FORMAT, Map())
+        makeRowKey(new GenericInternalRow(keys), types, FieldFactory.BINARY_FORMAT, Map(), new AstroKeyFactory)
       if (length < 0) completeRowKey
       else completeRowKey.take(length)
     }

--- a/src/test/scala/org/apache/spark/sql/hbase/HBaseBasicOperationSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hbase/HBaseBasicOperationSuite.scala
@@ -68,85 +68,85 @@ class HBaseBasicOperationSuite extends TestBaseWithSplitData {
 //    dropNativeHbaseTable("testNamespace.ht0")
 //  }
 
-  test("Insert and Query Single Row") {
-    try {
-      dropLogicalTable("tb1")
-    } catch {
-      case e: Throwable => logInfo(e.getMessage)
-    }
-    sql( """CREATE TABLE tb1 (column1 INTEGER, column2 STRING)
-           |USING org.apache.spark.sql.hbase.HBaseSource
-           |OPTIONS(
-           |  tableName "tb1",
-           |  hbaseTableName "ht1",
-           |  keyCols "column1",
-           |  colsMapping "column2=cf.cq"
-           |)""".stripMargin
-    )
-
-    assert(sql( """SELECT * FROM tb1""").collect().length == 0)
-    sql( """INSERT INTO TABLE tb1 VALUES (1024, "abc")""")
-    sql( """INSERT INTO TABLE tb1 VALUES (1028, "abd")""")
-    assert(sql( """SELECT * FROM tb1""").collect().length == 2)
-    assert(
-      sql( """SELECT * FROM tb1 WHERE (column1 = 1023 AND column2 ="abc")""").collect().length == 0)
-    assert(sql(
-      """SELECT * FROM tb1 WHERE (column1 = 1024)
-        |OR (column1 = 1028 AND column2 ="abd")""".stripMargin).collect().length == 2)
-
-    dropLogicalTable("tb1")
-    dropNativeHbaseTable("ht1")
-  }
-
-  test("Insert and Query Single Row in StringFormat") {
-    try {
-      dropLogicalTable("tb2")
-    } catch {
-      case e: Throwable => logInfo(e.getMessage)
-    }
-    sql( """CREATE TABLE tb1 (
-           |  col1 STRING,
-           |  col2 BOOLEAN,
-           |  col3 SMALLINT,
-           |  col4 INTEGER,
-           |  col5 LONG,
-           |  col6 FLOAT,
-           |  col7 DOUBLE
-           |)
-           |USING org.apache.spark.sql.hbase.HBaseSource
-           |OPTIONS(
-           |  tableName "tb1",
-           |  hbaseTableName "ht2",
-           |  keyCols "col1",
-           |  colsMapping "col2=cf1.cq11, col3=cf1.cq12, col4=cf1.cq13, col5=cf2.cq21, col6=cf2.cq22, col7=cf2.cq23",
-           |  encodingFormat "StringFormat"
-           |)""".stripMargin
-    )
-
-    assert(sql( """SELECT * FROM tb1""").collect().length == 0)
-    sql( """INSERT INTO TABLE tb1 VALUES ("row1", false, 1000, 5050 , 50000 , 99.99 , 999.999)""")
-    sql( """INSERT INTO TABLE tb1 VALUES ("row2", false, 99  , 10000, 9999  , 1000.1, 5000.5)""")
-    sql( """INSERT INTO TABLE tb1 VALUES ("row3", true , 555 , 999  , 100000, 500.05, 10000.01)""")
-    sql( """SELECT col1 FROM tb1 where col2<true order by col2""")
-      .collect().zip(Seq("row1", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
-    sql( """SELECT * FROM tb1 where col3>500 order by col3""")
-      .collect().zip(Seq("row3", "row1")).foreach{case (r,s) => assert(r.getString(0) == s)}
-    sql( """SELECT * FROM tb1 where col4>5000 order by col4""")
-      .collect().zip(Seq("row1", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
-    sql( """SELECT * FROM tb1 where col5>50000 order by col5""")
-      .collect().zip(Seq("row3")).foreach{case (r,s) => assert(r.getString(0) == s)}
-    sql( """SELECT * FROM tb1 where col6>500 order by col6""")
-      .collect().zip(Seq("row3", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
-    sql( """SELECT * FROM tb1 where col7>5000 order by col7""")
-      .collect().zip(Seq("row2", "row3")).foreach{case (r,s) => assert(r.getString(0) == s)}
-
-    dropLogicalTable("tb2")
-    dropNativeHbaseTable("ht2")
-  }
-
-  test("Select test 0") {
-    assert(sql( """SELECT * FROM ta""").count() == 14)
-  }
+//  test("Insert and Query Single Row") {
+//    try {
+//      dropLogicalTable("tb1")
+//    } catch {
+//      case e: Throwable => logInfo(e.getMessage)
+//    }
+//    sql( """CREATE TABLE tb1 (column1 INTEGER, column2 STRING)
+//           |USING org.apache.spark.sql.hbase.HBaseSource
+//           |OPTIONS(
+//           |  tableName "tb1",
+//           |  hbaseTableName "ht1",
+//           |  keyCols "column1",
+//           |  colsMapping "column2=cf.cq"
+//           |)""".stripMargin
+//    )
+//
+//    assert(sql( """SELECT * FROM tb1""").collect().length == 0)
+//    sql( """INSERT INTO TABLE tb1 VALUES (1024, "abc")""")
+//    sql( """INSERT INTO TABLE tb1 VALUES (1028, "abd")""")
+//    assert(sql( """SELECT * FROM tb1""").collect().length == 2)
+//    assert(
+//      sql( """SELECT * FROM tb1 WHERE (column1 = 1023 AND column2 ="abc")""").collect().length == 0)
+//    assert(sql(
+//      """SELECT * FROM tb1 WHERE (column1 = 1024)
+//        |OR (column1 = 1028 AND column2 ="abd")""".stripMargin).collect().length == 2)
+//
+//    dropLogicalTable("tb1")
+//    dropNativeHbaseTable("ht1")
+//  }
+//
+//  test("Insert and Query Single Row in StringFormat") {
+//    try {
+//      dropLogicalTable("tb2")
+//    } catch {
+//      case e: Throwable => logInfo(e.getMessage)
+//    }
+//    sql( """CREATE TABLE tb1 (
+//           |  col1 STRING,
+//           |  col2 BOOLEAN,
+//           |  col3 SMALLINT,
+//           |  col4 INTEGER,
+//           |  col5 LONG,
+//           |  col6 FLOAT,
+//           |  col7 DOUBLE
+//           |)
+//           |USING org.apache.spark.sql.hbase.HBaseSource
+//           |OPTIONS(
+//           |  tableName "tb1",
+//           |  hbaseTableName "ht2",
+//           |  keyCols "col1",
+//           |  colsMapping "col2=cf1.cq11, col3=cf1.cq12, col4=cf1.cq13, col5=cf2.cq21, col6=cf2.cq22, col7=cf2.cq23",
+//           |  encodingFormat "StringFormat"
+//           |)""".stripMargin
+//    )
+//
+//    assert(sql( """SELECT * FROM tb1""").collect().length == 0)
+//    sql( """INSERT INTO TABLE tb1 VALUES ("row1", false, 1000, 5050 , 50000 , 99.99 , 999.999)""")
+//    sql( """INSERT INTO TABLE tb1 VALUES ("row2", false, 99  , 10000, 9999  , 1000.1, 5000.5)""")
+//    sql( """INSERT INTO TABLE tb1 VALUES ("row3", true , 555 , 999  , 100000, 500.05, 10000.01)""")
+//    sql( """SELECT col1 FROM tb1 where col2<true order by col2""")
+//      .collect().zip(Seq("row1", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
+//    sql( """SELECT * FROM tb1 where col3>500 order by col3""")
+//      .collect().zip(Seq("row3", "row1")).foreach{case (r,s) => assert(r.getString(0) == s)}
+//    sql( """SELECT * FROM tb1 where col4>5000 order by col4""")
+//      .collect().zip(Seq("row1", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
+//    sql( """SELECT * FROM tb1 where col5>50000 order by col5""")
+//      .collect().zip(Seq("row3")).foreach{case (r,s) => assert(r.getString(0) == s)}
+//    sql( """SELECT * FROM tb1 where col6>500 order by col6""")
+//      .collect().zip(Seq("row3", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
+//    sql( """SELECT * FROM tb1 where col7>5000 order by col7""")
+//      .collect().zip(Seq("row2", "row3")).foreach{case (r,s) => assert(r.getString(0) == s)}
+//
+//    dropLogicalTable("tb2")
+//    dropNativeHbaseTable("ht2")
+//  }
+//
+//  test("Select test 0") {
+//    assert(sql( """SELECT * FROM ta""").count() == 14)
+//  }
 
   test("Count(*/1) and Non-Key Column Query") {
     assert(sql( """SELECT count(*) FROM ta""").collect()(0).get(0) == 14)

--- a/src/test/scala/org/apache/spark/sql/hbase/HBaseBasicOperationSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hbase/HBaseBasicOperationSuite.scala
@@ -68,85 +68,85 @@ class HBaseBasicOperationSuite extends TestBaseWithSplitData {
 //    dropNativeHbaseTable("testNamespace.ht0")
 //  }
 
-//  test("Insert and Query Single Row") {
-//    try {
-//      dropLogicalTable("tb1")
-//    } catch {
-//      case e: Throwable => logInfo(e.getMessage)
-//    }
-//    sql( """CREATE TABLE tb1 (column1 INTEGER, column2 STRING)
-//           |USING org.apache.spark.sql.hbase.HBaseSource
-//           |OPTIONS(
-//           |  tableName "tb1",
-//           |  hbaseTableName "ht1",
-//           |  keyCols "column1",
-//           |  colsMapping "column2=cf.cq"
-//           |)""".stripMargin
-//    )
-//
-//    assert(sql( """SELECT * FROM tb1""").collect().length == 0)
-//    sql( """INSERT INTO TABLE tb1 VALUES (1024, "abc")""")
-//    sql( """INSERT INTO TABLE tb1 VALUES (1028, "abd")""")
-//    assert(sql( """SELECT * FROM tb1""").collect().length == 2)
-//    assert(
-//      sql( """SELECT * FROM tb1 WHERE (column1 = 1023 AND column2 ="abc")""").collect().length == 0)
-//    assert(sql(
-//      """SELECT * FROM tb1 WHERE (column1 = 1024)
-//        |OR (column1 = 1028 AND column2 ="abd")""".stripMargin).collect().length == 2)
-//
-//    dropLogicalTable("tb1")
-//    dropNativeHbaseTable("ht1")
-//  }
-//
-//  test("Insert and Query Single Row in StringFormat") {
-//    try {
-//      dropLogicalTable("tb2")
-//    } catch {
-//      case e: Throwable => logInfo(e.getMessage)
-//    }
-//    sql( """CREATE TABLE tb1 (
-//           |  col1 STRING,
-//           |  col2 BOOLEAN,
-//           |  col3 SMALLINT,
-//           |  col4 INTEGER,
-//           |  col5 LONG,
-//           |  col6 FLOAT,
-//           |  col7 DOUBLE
-//           |)
-//           |USING org.apache.spark.sql.hbase.HBaseSource
-//           |OPTIONS(
-//           |  tableName "tb1",
-//           |  hbaseTableName "ht2",
-//           |  keyCols "col1",
-//           |  colsMapping "col2=cf1.cq11, col3=cf1.cq12, col4=cf1.cq13, col5=cf2.cq21, col6=cf2.cq22, col7=cf2.cq23",
-//           |  encodingFormat "StringFormat"
-//           |)""".stripMargin
-//    )
-//
-//    assert(sql( """SELECT * FROM tb1""").collect().length == 0)
-//    sql( """INSERT INTO TABLE tb1 VALUES ("row1", false, 1000, 5050 , 50000 , 99.99 , 999.999)""")
-//    sql( """INSERT INTO TABLE tb1 VALUES ("row2", false, 99  , 10000, 9999  , 1000.1, 5000.5)""")
-//    sql( """INSERT INTO TABLE tb1 VALUES ("row3", true , 555 , 999  , 100000, 500.05, 10000.01)""")
-//    sql( """SELECT col1 FROM tb1 where col2<true order by col2""")
-//      .collect().zip(Seq("row1", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
-//    sql( """SELECT * FROM tb1 where col3>500 order by col3""")
-//      .collect().zip(Seq("row3", "row1")).foreach{case (r,s) => assert(r.getString(0) == s)}
-//    sql( """SELECT * FROM tb1 where col4>5000 order by col4""")
-//      .collect().zip(Seq("row1", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
-//    sql( """SELECT * FROM tb1 where col5>50000 order by col5""")
-//      .collect().zip(Seq("row3")).foreach{case (r,s) => assert(r.getString(0) == s)}
-//    sql( """SELECT * FROM tb1 where col6>500 order by col6""")
-//      .collect().zip(Seq("row3", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
-//    sql( """SELECT * FROM tb1 where col7>5000 order by col7""")
-//      .collect().zip(Seq("row2", "row3")).foreach{case (r,s) => assert(r.getString(0) == s)}
-//
-//    dropLogicalTable("tb2")
-//    dropNativeHbaseTable("ht2")
-//  }
-//
-//  test("Select test 0") {
-//    assert(sql( """SELECT * FROM ta""").count() == 14)
-//  }
+  test("Insert and Query Single Row") {
+    try {
+      dropLogicalTable("tb1")
+    } catch {
+      case e: Throwable => logInfo(e.getMessage)
+    }
+    sql( """CREATE TABLE tb1 (column1 INTEGER, column2 STRING)
+           |USING org.apache.spark.sql.hbase.HBaseSource
+           |OPTIONS(
+           |  tableName "tb1",
+           |  hbaseTableName "ht1",
+           |  keyCols "column1",
+           |  colsMapping "column2=cf.cq"
+           |)""".stripMargin
+    )
+
+    assert(sql( """SELECT * FROM tb1""").collect().length == 0)
+    sql( """INSERT INTO TABLE tb1 VALUES (1024, "abc")""")
+    sql( """INSERT INTO TABLE tb1 VALUES (1028, "abd")""")
+    assert(sql( """SELECT * FROM tb1""").collect().length == 2)
+    assert(
+      sql( """SELECT * FROM tb1 WHERE (column1 = 1023 AND column2 ="abc")""").collect().length == 0)
+    assert(sql(
+      """SELECT * FROM tb1 WHERE (column1 = 1024)
+        |OR (column1 = 1028 AND column2 ="abd")""".stripMargin).collect().length == 2)
+
+    dropLogicalTable("tb1")
+    dropNativeHbaseTable("ht1")
+  }
+
+  test("Insert and Query Single Row in StringFormat") {
+    try {
+      dropLogicalTable("tb2")
+    } catch {
+      case e: Throwable => logInfo(e.getMessage)
+    }
+    sql( """CREATE TABLE tb1 (
+           |  col1 STRING,
+           |  col2 BOOLEAN,
+           |  col3 SMALLINT,
+           |  col4 INTEGER,
+           |  col5 LONG,
+           |  col6 FLOAT,
+           |  col7 DOUBLE
+           |)
+           |USING org.apache.spark.sql.hbase.HBaseSource
+           |OPTIONS(
+           |  tableName "tb1",
+           |  hbaseTableName "ht2",
+           |  keyCols "col1",
+           |  colsMapping "col2=cf1.cq11, col3=cf1.cq12, col4=cf1.cq13, col5=cf2.cq21, col6=cf2.cq22, col7=cf2.cq23",
+           |  encodingFormat "StringFormat"
+           |)""".stripMargin
+    )
+
+    assert(sql( """SELECT * FROM tb1""").collect().length == 0)
+    sql( """INSERT INTO TABLE tb1 VALUES ("row1", false, 1000, 5050 , 50000 , 99.99 , 999.999)""")
+    sql( """INSERT INTO TABLE tb1 VALUES ("row2", false, 99  , 10000, 9999  , 1000.1, 5000.5)""")
+    sql( """INSERT INTO TABLE tb1 VALUES ("row3", true , 555 , 999  , 100000, 500.05, 10000.01)""")
+    sql( """SELECT col1 FROM tb1 where col2<true order by col2""")
+      .collect().zip(Seq("row1", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
+    sql( """SELECT * FROM tb1 where col3>500 order by col3""")
+      .collect().zip(Seq("row3", "row1")).foreach{case (r,s) => assert(r.getString(0) == s)}
+    sql( """SELECT * FROM tb1 where col4>5000 order by col4""")
+      .collect().zip(Seq("row1", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
+    sql( """SELECT * FROM tb1 where col5>50000 order by col5""")
+      .collect().zip(Seq("row3")).foreach{case (r,s) => assert(r.getString(0) == s)}
+    sql( """SELECT * FROM tb1 where col6>500 order by col6""")
+      .collect().zip(Seq("row3", "row2")).foreach{case (r,s) => assert(r.getString(0) == s)}
+    sql( """SELECT * FROM tb1 where col7>5000 order by col7""")
+      .collect().zip(Seq("row2", "row3")).foreach{case (r,s) => assert(r.getString(0) == s)}
+
+    dropLogicalTable("tb2")
+    dropNativeHbaseTable("ht2")
+  }
+
+  test("Select test 0") {
+    assert(sql( """SELECT * FROM ta""").count() == 14)
+  }
 
   test("Count(*/1) and Non-Key Column Query") {
     assert(sql( """SELECT count(*) FROM ta""").collect()(0).get(0) == 14)

--- a/src/test/scala/org/apache/spark/sql/hbase/HBasePartitionerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hbase/HBasePartitionerSuite.scala
@@ -62,7 +62,9 @@ class HBasePartitionerSuite extends TestBase {
       asInstanceOf[PrimitiveDataField]
     val fieldDataString = FieldFactory.createFieldData(StringType, FieldFactory.BINARY_FORMAT, Array[Byte]())
 
-    val rowkey = HBaseKVHelper.encodingRawKeyColumns(
+    val keyFactory = new AstroKeyFactory
+
+    val rowkey = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataDouble.getRawBytes(123.456.asInstanceOf[fieldDataDouble.InternalType]), DoubleType),
         (fieldDataString.
           getRawBytes(UTF8String.fromString("abcdef").asInstanceOf[fieldDataString.InternalType]), StringType),
@@ -72,7 +74,7 @@ class HBasePartitionerSuite extends TestBase {
 
     assert(rowkey.length === 8 + 6 + 1 + 1 + 4)
 
-    val keys = HBaseKVHelper.decodingRawKeyColumns(rowkey,
+    val keys = keyFactory.decodingRawKeyColumns(rowkey,
       Seq(KeyColumn("col1", DoubleType, 0, FieldFactory.createFieldData(DoubleType,
         FieldFactory.BINARY_FORMAT, Array[Byte]())),
         KeyColumn("col2", StringType, 1,FieldFactory.createFieldData(StringType,
@@ -95,7 +97,8 @@ class HBasePartitionerSuite extends TestBase {
     val fieldDataDouble = FieldFactory.createFieldData(DoubleType, FieldFactory.BINARY_FORMAT, Array[Byte]())
       .asInstanceOf[PrimitiveDataField]
     val fieldDataString = FieldFactory.createFieldData(StringType, FieldFactory.BINARY_FORMAT, Array[Byte]())
-    val rowkey = HBaseKVHelper.encodingRawKeyColumns(
+    val keyFactory = new AstroKeyFactory
+    val rowkey = keyFactory.encodingRawKeyColumns(
         Seq((fieldDataDouble.getRawBytes(123.456.asInstanceOf[fieldDataDouble.InternalType]), DoubleType),
         (fieldDataString.
           getRawBytes(UTF8String.fromString("abcdef").asInstanceOf[fieldDataString.InternalType]), StringType),
@@ -104,7 +107,7 @@ class HBasePartitionerSuite extends TestBase {
 
     assert(rowkey.length === 8 + 6 + 1 + 4)
 
-    val keys = HBaseKVHelper.decodingRawKeyColumns(rowkey,
+    val keys = keyFactory.decodingRawKeyColumns(rowkey,
       Seq(KeyColumn("col1", DoubleType, 0,
         FieldFactory.createFieldData(DoubleType, FieldFactory.BINARY_FORMAT, Array[Byte]())),
         KeyColumn("col2", StringType, 1,
@@ -172,28 +175,29 @@ class HBasePartitionerSuite extends TestBase {
     assert(expandedCPRs.size == 4)
 
     val fieldDataInteger = FieldFactory.createFieldData(IntegerType, FieldFactory.BINARY_FORMAT, Array[Byte]())
+    val keyFactory = new AstroKeyFactory
 
-    val rowkey0 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey0 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(1.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(1.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey1 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey1 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(8.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(2.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey2 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey2 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(32.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(16.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey3 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey3 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(64.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(128.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )
 
-    val rowkey4 = HBaseKVHelper.encodingRawKeyColumns(
+    val rowkey4 = keyFactory.encodingRawKeyColumns(
       Seq((fieldDataInteger.getRawBytes(1024.asInstanceOf[fieldDataInteger.InternalType]), IntegerType)
         , (fieldDataInteger.getRawBytes(256.asInstanceOf[fieldDataInteger.InternalType]), IntegerType))
     )

--- a/src/test/scala/org/apache/spark/sql/hbase/TestBaseWithSplitData.scala
+++ b/src/test/scala/org/apache/spark/sql/hbase/TestBaseWithSplitData.scala
@@ -140,7 +140,7 @@ class TestBaseWithSplitData extends TestBase {
     def putNewTableIntoHBase(keys: Seq[Any], keysType: Seq[DataType],
                              vals: Seq[Any], valsType: Seq[DataType]): Unit = {
       val row = new GenericInternalRow(keys.toArray)
-      val key = HBaseKVHelper.makeRowKey(row, keysType, FieldFactory.BINARY_FORMAT, Map())
+      val key = HBaseKVHelper.makeRowKey(row, keysType, FieldFactory.BINARY_FORMAT, Map(), new AstroKeyFactory())
       val put = new Put(key)
       Seq((vals.head, valsType.head, "cf1", "cq11"),
         (vals(1), valsType(1), "cf1", "cq12"),


### PR DESCRIPTION
Supporting new type of row key format called SimpleKey, this key is composed with some delimiters like '~,!,@,#,$,%,^,&,*,(,),..etc'. 
For example 
col1 INT, col2 INT, col3 String, col4 INT
then key would be composed as follows if deleimiter is '~' 
 col1 ~ col2 ~ col3 ~ col4

User needs to give ```keySeparator``` while creating the table. if ```keySeparator``` is present then it picks SimpleKeyFactory, otherwise it picks AstroKeyFactory.

For example :

```
CREATE TABLE $TestSimpleKeyTableName(
  strcol STRING,
  bytecol TINYINT,
  shortcol SMALLINT,
  intcol INTEGER,
  longcol LONG,
  floatcol FLOAT,
  doublecol DOUBLE
)
USING org.apache.spark.sql.hbase.HBaseSource
OPTIONS(
  hbaseTableName "$TestHBaseSimpleKeyTableName",
  keyCols "doublecol, strcol, intcol",
  colsMapping "bytecol=cf1.hbytecol, shortcol=cf1.hshortcol, longcol=cf2.hlongcol, floatcol=cf2.hfloatcol",
  keySeparator "~"
)
```
In the above example ```keySeparator``` is present, so it picks SimpleKeyFactory. 